### PR TITLE
Add i2c functions

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -14,6 +14,7 @@ use crate::{
         CGOS_BOARD_CLASS_CPU, CGOS_BOARD_CLASS_IO, CGOS_BOARD_CLASS_VGA,
     },
     fan::Fan,
+    i2c::{I2c, I2cResult},
     storage_area::{StorageArea, StorageAreaType},
     temperature::Temperature,
 };
@@ -122,6 +123,14 @@ impl<'library> Board<'library> {
         type_: StorageAreaType,
     ) -> StorageArea<'library> {
         StorageArea::from_type(self.handle, type_)
+    }
+
+    pub fn get_number_of_i2c(&'library self) -> usize {
+        I2c::amount(self.handle)
+    }
+
+    pub fn get_i2c(&'library self, index: usize) -> I2cResult<I2c<'library>> {
+        I2c::new(self.handle, index)
     }
 }
 

--- a/src/board.rs
+++ b/src/board.rs
@@ -125,7 +125,7 @@ impl<'library> Board<'library> {
         StorageArea::from_type(self.handle, type_)
     }
 
-    pub fn get_number_of_i2c(&'library self) -> usize {
+    pub fn get_number_of_i2c(&self) -> usize {
         I2c::amount(self.handle)
     }
 

--- a/src/board.rs
+++ b/src/board.rs
@@ -14,7 +14,7 @@ use crate::{
         CGOS_BOARD_CLASS_CPU, CGOS_BOARD_CLASS_IO, CGOS_BOARD_CLASS_VGA,
     },
     fan::Fan,
-    i2c::{I2c, I2cResult},
+    i2c::{I2c, Result},
     storage_area::{StorageArea, StorageAreaType},
     temperature::Temperature,
 };
@@ -129,7 +129,7 @@ impl<'library> Board<'library> {
         I2c::amount(self.handle)
     }
 
-    pub fn get_i2c(&'library self, index: usize) -> I2cResult<I2c<'library>> {
+    pub fn get_i2c(&'library self, index: usize) -> Result<I2c<'library>> {
         I2c::new(self.handle, index)
     }
 }

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -1,0 +1,217 @@
+use std::marker::PhantomData;
+
+use crate::bindings::{
+    CgosI2CCount, CgosI2CGetFrequency, CgosI2CGetMaxFrequency, CgosI2CIsAvailable, CgosI2CRead,
+    CgosI2CReadRegister, CgosI2CSetFrequency, CgosI2CType, CgosI2CWrite, CgosI2CWriteReadCombined,
+    CgosI2CWriteRegister, CGOS_I2C_TYPE_DDC, CGOS_I2C_TYPE_PRIMARY, CGOS_I2C_TYPE_SMB,
+    CGOS_I2C_TYPE_UNKNOWN,
+};
+
+/// Error type for I2c operations
+#[derive(PartialEq, Eq, Clone, Debug)]
+pub enum I2cErr {
+    /// User-supplied index is out of range
+    IdxOutOfRange,
+
+    /// I2c bus transaction failed
+    BusErr,
+}
+
+pub type I2cResult<T> = Result<T, I2cErr>;
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum I2cType {
+    Unknown,
+    Primary,
+    Smb,
+    Ddc,
+    CongatecInternalUse(u32),
+}
+
+impl Into<u32> for I2cType {
+    fn into(self) -> u32 {
+        match self {
+            Self::Unknown => CGOS_I2C_TYPE_UNKNOWN,
+            Self::Primary => CGOS_I2C_TYPE_PRIMARY,
+            Self::Smb => CGOS_I2C_TYPE_SMB,
+            Self::Ddc => CGOS_I2C_TYPE_DDC,
+            Self::CongatecInternalUse(x) => x,
+        }
+    }
+}
+
+impl From<u32> for I2cType {
+    //note: On my devboard libcgos does return undeclared values for some busses, hence the need to return an error instead of panic
+    fn from(value: u32) -> I2cType {
+        match value {
+            CGOS_I2C_TYPE_UNKNOWN => Self::Unknown,
+            CGOS_I2C_TYPE_PRIMARY => Self::Primary,
+            CGOS_I2C_TYPE_SMB => Self::Smb,
+            CGOS_I2C_TYPE_DDC => Self::Ddc,
+            _ => Self::CongatecInternalUse(value),
+        }
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct I2c<'library> {
+    handle: u32,
+    index: u32,
+    _library_lifetime: PhantomData<&'library ()>,
+}
+impl<'library> I2c<'library> {
+    pub(crate) fn new(handle: u32, index: usize) -> I2cResult<Self> {
+        let num_busses = Self::amount(handle);
+        if index > num_busses.saturating_sub(1) {
+            return Err(I2cErr::IdxOutOfRange);
+        }
+
+        let index = index.try_into().map_err(|_| I2cErr::IdxOutOfRange)?;
+        let ret = Self {
+            handle,
+            index: index,
+            _library_lifetime: PhantomData,
+        };
+        Ok(ret)
+    }
+
+    pub(crate) fn amount(handle: u32) -> usize {
+        unsafe { CgosI2CCount(handle) as usize }
+    }
+
+    pub fn i2c_type(&'library self) -> I2cType {
+        let raw = unsafe { CgosI2CType(self.handle, self.index) };
+        I2cType::from(raw)
+    }
+
+    pub fn is_available(&'library self) -> bool {
+        let raw = unsafe { CgosI2CIsAvailable(self.handle, self.index) };
+        raw == 1
+    }
+
+    pub fn read(&'library self, bus_addr: u8, rd_data: &mut [u8]) -> I2cResult<()> {
+        let retcode = unsafe {
+            CgosI2CRead(
+                self.handle,
+                self.index,
+                bus_addr,
+                rd_data.as_mut_ptr(),
+                rd_data.len() as u32,
+            )
+        };
+
+        if retcode != 0 {
+            return Ok(());
+        } else {
+            return Err(I2cErr::BusErr);
+        }
+    }
+
+    pub fn write(&'library self, bus_addr: u8, wr_data: &[u8]) -> I2cResult<()> {
+        let retcode = unsafe {
+            dbg!(&wr_data, self.handle, self.index);
+            CgosI2CWrite(
+                self.handle,
+                self.index,
+                bus_addr,
+                wr_data.as_ptr() as *mut u8,
+                wr_data.len() as u32,
+            )
+        };
+
+        if retcode != 0 {
+            return Ok(());
+        } else {
+            return Err(I2cErr::BusErr);
+        }
+    }
+
+    pub fn read_register(&'library self, bus_addr: u8, reg_addr: u16) -> I2cResult<u8> {
+        let mut ret: u8 = 0;
+        let retval = unsafe {
+            CgosI2CReadRegister(
+                self.handle,
+                self.index,
+                bus_addr,
+                reg_addr,
+                &mut ret as *mut u8,
+            )
+        };
+
+        if retval != 0 {
+            Ok(ret)
+        } else {
+            Err(I2cErr::BusErr)
+        }
+    }
+
+    pub fn write_register(&'library self, bus_addr: u8, reg_addr: u16, val: u8) -> I2cResult<()> {
+        let retval =
+            unsafe { CgosI2CWriteRegister(self.handle, self.index, bus_addr, reg_addr, val) };
+
+        if retval != 0 {
+            Ok(())
+        } else {
+            Err(I2cErr::BusErr)
+        }
+    }
+
+    pub fn write_read_combined(
+        &'library self,
+        bus_addr: u8,
+        wr_data: &[u8],
+        rd_data: &mut [u8],
+    ) -> I2cResult<()> {
+        let wr_len = wr_data.len();
+        let retval = unsafe {
+            CgosI2CWriteReadCombined(
+                self.handle,
+                self.index,
+                bus_addr,
+                wr_data.as_ptr() as *mut u8,
+                wr_len.try_into().unwrap(),
+                rd_data.as_mut_ptr(),
+                rd_data.len() as u32,
+            )
+        };
+
+        if retval != 0 {
+            return Ok(());
+        } else {
+            return Err(I2cErr::BusErr);
+        }
+    }
+
+    pub fn get_max_frequency(&'library self) -> I2cResult<u32> {
+        let mut ret = 0;
+        let retval =
+            unsafe { CgosI2CGetMaxFrequency(self.handle, self.index, &mut ret as *mut u32) };
+
+        if retval != 0 {
+            return Ok(ret);
+        } else {
+            return Err(I2cErr::BusErr);
+        }
+    }
+
+    pub fn get_frequency(&'library self) -> I2cResult<u32> {
+        let mut ret = 0;
+        let retval = unsafe { CgosI2CGetFrequency(self.handle, self.index, &mut ret as *mut u32) };
+
+        if retval != 0 {
+            return Ok(ret);
+        } else {
+            return Err(I2cErr::BusErr);
+        }
+    }
+
+    pub fn set_frequency(&'library self, frequency: u32) -> I2cResult<()> {
+        let retval = unsafe { CgosI2CSetFrequency(self.handle, self.index, frequency) };
+
+        if retval != 0 {
+            return Ok(());
+        } else {
+            return Err(I2cErr::BusErr);
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,3 +5,5 @@ pub mod fan;
 pub mod status;
 pub mod storage_area;
 pub mod temperature;
+pub mod i2c;
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,4 +6,3 @@ pub mod status;
 pub mod storage_area;
 pub mod temperature;
 pub mod i2c;
-


### PR DESCRIPTION
Integrate all of the cgos i2c described in v1.4 of the API reference.

Read and write functions have been tested against an external i2c sensor plugged into DDC bus an SEVAL devboard, with a SA7 SMARC running debian 12 (kernel 6.10.11+bpo-amd64)

Design decisions:
* This implementation is mostly a direct translation of the C API. I considered making the read functions return freshly allocated vectors as this is significantly more ergonomic, but decided against this. I think it should be easy enough for users to write their own wrappers for this.
* Because the Congatec API reference does not specify what happens when an invalid dwUnit is supplied to any functiona call, I am conservatively assuming this causes undefined behaviour in libcgos. I have added protections against this in `I2c::new`  when instantiating an i2c bus object. The alternative would be to mark all i2c-related functions as unsafe.
* The code should be panic-free

(Thanks for the quick response to yesterday's request!)